### PR TITLE
corrected copy&paste error

### DIFF
--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -20,5 +20,5 @@
   value:        (settings.honeypotParam ?: ''),
   disabled:     'honeypotParam' in overrides,
   warning:      'honeypotParam' in overrides ? configWarning('honeypotParam'),
-  errors:       settings.getErrors('prependSender')
+  errors:       settings.getErrors('honeypotParam')
 }) }}


### PR DESCRIPTION
it probably never ever surfaces (since `honeypotParam` validation rules are very broad) but the attribute name in the getErrors call is wrong